### PR TITLE
بهبود UI/UX: ادمین، پنل کاربر و لندینگ + پایداری بیلد و e2e

### DIFF
--- a/admin-ui/package-lock.json
+++ b/admin-ui/package-lock.json
@@ -16,6 +16,8 @@
         "framer-motion": "^11.2.12",
         "jalali-react-datepicker": "^1.2.1",
         "lucide-react": "^0.408.0",
+        "maplibre-gl": "^5.22.0",
+        "posthog-js": "^1.364.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.52.1",
@@ -1247,6 +1249,111 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
+      "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.0.4.tgz",
+      "integrity": "sha512-HYv3POhMRCdhP3UPPATM/hfcy6/WuVIf5FKboH8u/ZuFMTnAIcSVlq5nfOqroLokd925w2QtE7YwquFOIacwVQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
+      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.8.tgz",
+      "integrity": "sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "license": "ISC"
+    },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
       "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
@@ -1325,6 +1432,252 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@playwright/test": {
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
@@ -1340,6 +1693,82 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.24.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.24.6.tgz",
+      "integrity": "sha512-9WkcRKqmXSWIJcca6m3VwA9YbFd4HiG2hKEtDq6FcwEHlvfDhQQUZ5/sJZ47Fw8OtyNMHQ6rW4+COttk4Bg5NQ==",
+      "license": "MIT"
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.364.7",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.364.7.tgz",
+      "integrity": "sha512-Rg6q4wSu8krrn8f3Nv44kGXjor4qh5iG0typt2sB7/SYQFRSbXYE2C46+qDMcBYGxmRMsWBitBcZ9x94DQCnfA==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -1848,11 +2277,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1892,6 +2326,22 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
@@ -2894,6 +3344,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3210,6 +3671,15 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3223,6 +3693,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.329",
@@ -3678,6 +4154,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -3929,6 +4411,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -4545,6 +5033,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -4557,6 +5051,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -4645,6 +5145,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4691,6 +5197,40 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/maplibre-gl": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.22.0.tgz",
+      "integrity": "sha512-nc8YA+YSEioMZg5W0cb6Cf3wQ8aJge66dsttyBgpOArOnlmFJO1Kc5G32kYVPeUYhLpBja83T99uanmJvYAIyQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.7",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.0.4",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4768,6 +5308,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/moment": {
@@ -4874,6 +5423,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -5159,6 +5714,18 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5398,6 +5965,43 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/posthog-js": {
+      "version": "1.364.7",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.364.7.tgz",
+      "integrity": "sha512-mjYUjim0PSNUjxbGR8MGl7hnbbJMCU+Dy4gRexMRGMRlZT9tskGzsgS4Q6Cvx+63lpkQg5kJrC4bHCuILnQ4/A==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.24.6",
+        "@posthog/types": "1.364.7",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5423,6 +6027,36 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
@@ -5472,6 +6106,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
+    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -5497,6 +6137,12 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -5731,6 +6377,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -5861,6 +6516,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -6107,6 +6768,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6316,6 +6986,12 @@
         "node": "^18.0.0 || >=20.0.0"
       }
     },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
+    },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
@@ -6465,7 +7141,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -6736,6 +7411,12 @@
       "dependencies": {
         "defaults": "^1.0.3"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/admin-ui/package.json
+++ b/admin-ui/package.json
@@ -22,6 +22,8 @@
     "framer-motion": "^11.2.12",
     "jalali-react-datepicker": "^1.2.1",
     "lucide-react": "^0.408.0",
+    "maplibre-gl": "^5.22.0",
+    "posthog-js": "^1.364.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.52.1",
@@ -46,14 +48,14 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.8",
+    "fast-check": "^3.23.2",
+    "jsdom": "^24.1.3",
     "msw": "^2.12.14",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.6",
     "typescript": "^5.5.3",
     "vite": "^5.3.4",
-    "vitest": "^2.1.9",
-    "fast-check": "^3.23.2",
-    "jsdom": "^24.1.3"
+    "vitest": "^2.1.9"
   },
   "msw": {
     "workerDirectory": [

--- a/admin-ui/playwright.config.ts
+++ b/admin-ui/playwright.config.ts
@@ -7,6 +7,7 @@ const baseURL = `http://${devServerHost}:${devServerPort}`;
 export default defineConfig({
   testDir: './tests',
   timeout: 60_000,
+  workers: 2,
   retries: process.env.CI ? 1 : 0,
   forbidOnly: !!process.env.CI,
   use: {
@@ -28,7 +29,7 @@ export default defineConfig({
       ...process.env,
       // بدون .env.local در CI: MSW + ورود آزمایشی برای تست‌های e2e/full-user-flow
       VITE_USE_MSW: process.env.VITE_USE_MSW ?? 'true',
-      VITE_ENABLE_DEV_BYPASS: process.env.VITE_ENABLE_DEV_BYPASS ?? 'true',
+      VITE_ENABLE_DEV_BYPASS: 'true',
       // اگر .env.local لوکال به پورت خالی اشاره کند، Playwright همچنان پایدار بماند
       VITE_DEV_PROXY_TARGET: process.env.VITE_DEV_PROXY_TARGET ?? 'https://api.amline.ir',
     },

--- a/admin-ui/src/index.css
+++ b/admin-ui/src/index.css
@@ -111,6 +111,20 @@ body {
   @apply text-xs text-[var(--amline-fg-subtle)];
 }
 
+/* دسترسی‌پذیری: فوکوس مرئی برای کنترل‌های تعاملی */
+@layer base {
+  :where(a, button, input, textarea, select, summary, [tabindex]:not([tabindex='-1'])):focus-visible {
+    outline: 2px solid var(--amline-ring);
+    outline-offset: 2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 /* اسکرول‌بار */
 ::-webkit-scrollbar {
   width: 8px;

--- a/admin-ui/src/layouts/MainLayout.tsx
+++ b/admin-ui/src/layouts/MainLayout.tsx
@@ -1,6 +1,26 @@
 import { useState } from 'react';
 import { Outlet, NavLink, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import type { LucideIcon } from 'lucide-react';
+import {
+  Activity,
+  Bell,
+  ClipboardList,
+  FileText,
+  LayoutDashboard,
+  LayoutGrid,
+  Menu,
+  PenLine,
+  Plug,
+  Receipt,
+  ScrollText,
+  Settings,
+  Shield,
+  Tag,
+  Users,
+  Wallet,
+  X,
+} from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { cn } from '../lib/cn';
@@ -9,25 +29,25 @@ import { apiClient } from '../lib/api';
 type NavConfig = {
   to: string;
   label: string;
-  icon: string;
+  icon: LucideIcon;
   permission?: string;
 };
 
 const NAV_CONFIG: NavConfig[] = [
-  { to: '/dashboard', label: 'داشبورد', icon: '🏠' },
-  { to: '/contracts', label: 'قراردادها', icon: '📄', permission: 'contracts:read' },
-  { to: '/contracts/wizard', label: 'قرارداد جدید', icon: '✍️', permission: 'contracts:write' },
-  { to: '/crm', label: 'CRM', icon: '📊' },
-  { to: '/ads', label: 'آگهی‌ها', icon: '🏷️', permission: 'ads:read' },
-  { to: '/users', label: 'کاربران', icon: '👥', permission: 'users:read' },
-  { to: '/wallets', label: 'کیف پول', icon: '💳', permission: 'wallets:read' },
-  { to: '/payments', label: 'پرداخت‌ها', icon: '🧾', permission: 'wallets:read' },
-  { to: '/billing', label: 'اشتراک', icon: '📋', permission: 'wallets:read' },
-  { to: '/settings', label: 'تنظیمات', icon: '⚙️', permission: 'settings:read' },
-  { to: '/integrations', label: 'یکپارچه‌سازی', icon: '🔌', permission: 'settings:read' },
-  { to: '/admin/roles', label: 'نقش‌ها', icon: '🔐', permission: 'roles:read' },
-  { to: '/admin/audit', label: 'ممیزی', icon: '📋', permission: 'audit:read' },
-  { to: '/admin/activity', label: 'گزارش فعالیت', icon: '📈', permission: 'reports:read' },
+  { to: '/dashboard', label: 'داشبورد', icon: LayoutDashboard },
+  { to: '/contracts', label: 'قراردادها', icon: FileText, permission: 'contracts:read' },
+  { to: '/contracts/wizard', label: 'قرارداد جدید', icon: PenLine, permission: 'contracts:write' },
+  { to: '/crm', label: 'CRM', icon: LayoutGrid },
+  { to: '/ads', label: 'آگهی‌ها', icon: Tag, permission: 'ads:read' },
+  { to: '/users', label: 'کاربران', icon: Users, permission: 'users:read' },
+  { to: '/wallets', label: 'کیف پول', icon: Wallet, permission: 'wallets:read' },
+  { to: '/payments', label: 'پرداخت‌ها', icon: Receipt, permission: 'wallets:read' },
+  { to: '/billing', label: 'اشتراک', icon: ClipboardList, permission: 'wallets:read' },
+  { to: '/settings', label: 'تنظیمات', icon: Settings, permission: 'settings:read' },
+  { to: '/integrations', label: 'یکپارچه‌سازی', icon: Plug, permission: 'settings:read' },
+  { to: '/admin/roles', label: 'نقش‌ها', icon: Shield, permission: 'roles:read' },
+  { to: '/admin/audit', label: 'ممیزی', icon: ScrollText, permission: 'audit:read' },
+  { to: '/admin/activity', label: 'گزارش فعالیت', icon: Activity, permission: 'reports:read' },
 ];
 
 function NotificationsBell() {
@@ -52,11 +72,11 @@ function NotificationsBell() {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className="relative flex h-10 w-10 items-center justify-center rounded-amline-md border border-[var(--amline-border)] text-lg hover:bg-[var(--amline-surface-muted)] dark:border-slate-600"
+        className="relative flex h-10 w-10 items-center justify-center rounded-amline-md border border-[var(--amline-border)] text-[var(--amline-primary)] transition-colors hover:bg-[var(--amline-surface-muted)] dark:border-slate-600"
         aria-expanded={open}
         aria-label="اعلان‌ها"
       >
-        🔔
+        <Bell className="h-5 w-5" strokeWidth={1.75} aria-hidden />
         {unread > 0 ? (
           <span className="absolute -left-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold text-white">
             {unread > 9 ? '9+' : unread}
@@ -71,7 +91,7 @@ function NotificationsBell() {
             aria-label="بستن اعلان‌ها"
             onClick={() => setOpen(false)}
           />
-          <div className="absolute left-0 top-full z-50 mt-2 w-[min(22rem,calc(100vw-2rem))] rounded-amline-md border border-[var(--amline-border)] bg-[var(--amline-surface)] p-2 shadow-amline dark:border-slate-700">
+          <div className="absolute left-0 top-full z-50 mt-2 w-[min(22rem,calc(100vw-2rem))] animate-fadeIn rounded-amline-lg border border-[var(--amline-border)] bg-[var(--amline-surface)] p-2 shadow-[var(--amline-shadow-lg)] dark:border-slate-700">
             {items.length === 0 ? (
               <p className="px-3 py-4 text-center text-sm text-[var(--amline-fg-muted)]">اعلانی نیست</p>
             ) : (
@@ -111,16 +131,16 @@ export default function MainLayout() {
   return (
     <div dir="rtl" className="flex min-h-screen bg-[var(--amline-bg)] text-[var(--amline-fg)] transition-colors">
       {/* نوار بالا — موبایل و تبلت */}
-      <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center justify-between border-b border-[var(--amline-border)] bg-[var(--amline-surface)]/95 px-4 shadow-[var(--amline-shadow-sm)] backdrop-blur-md dark:border-slate-700 dark:bg-slate-900/95 lg:hidden">
+      <header className="fixed inset-x-0 top-0 z-40 flex h-14 items-center justify-between border-b border-[var(--amline-border)] bg-[var(--amline-surface)]/90 px-4 shadow-[var(--amline-shadow-sm)] backdrop-blur-xl dark:border-slate-700 dark:bg-slate-900/90 lg:hidden">
         <button
           type="button"
-          className="flex h-11 w-11 items-center justify-center rounded-amline-md border border-[var(--amline-border)] text-lg text-[var(--amline-fg)] transition-colors hover:bg-[var(--amline-surface-muted)] dark:border-slate-600"
+          className="flex h-11 w-11 items-center justify-center rounded-amline-md border border-[var(--amline-border)] text-[var(--amline-fg)] transition-colors duration-200 hover:bg-[var(--amline-surface-muted)] active:scale-[0.98] dark:border-slate-600"
           onClick={() => setMobileNavOpen(true)}
           aria-expanded={mobileNavOpen}
           aria-controls="app-sidebar"
           aria-label="باز کردن منو"
         >
-          ☰
+          <Menu className="h-5 w-5" strokeWidth={1.75} aria-hidden />
         </button>
         <div className="flex flex-col items-center">
           <span className="text-base font-bold text-[var(--amline-primary)]">اَملاین</span>
@@ -147,7 +167,7 @@ export default function MainLayout() {
       <aside
         id="app-sidebar"
         className={cn(
-          'fixed inset-y-0 right-0 z-50 flex w-[min(20rem,88vw)] flex-col border-l border-[var(--amline-border)] bg-[var(--amline-surface)] shadow-amline transition-transform duration-300 ease-out dark:border-slate-700 dark:shadow-none lg:static lg:z-0 lg:w-64 lg:max-w-none lg:translate-x-0 lg:shadow-none',
+          'fixed inset-y-0 right-0 z-50 flex w-[min(20rem,88vw)] flex-col border-l border-[var(--amline-border)] bg-[var(--amline-surface)] shadow-[var(--amline-shadow-lg)] transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] dark:border-slate-700 dark:shadow-none lg:static lg:z-0 lg:w-64 lg:max-w-none lg:translate-x-0 lg:shadow-none',
           mobileNavOpen ? 'translate-x-0' : 'translate-x-full lg:translate-x-0'
         )}
       >
@@ -162,34 +182,37 @@ export default function MainLayout() {
           </div>
           <button
             type="button"
-            className="flex h-10 w-10 items-center justify-center rounded-amline-md text-xl text-[var(--amline-fg-muted)] hover:bg-[var(--amline-surface-muted)] lg:hidden"
+            className="flex h-10 w-10 items-center justify-center rounded-amline-md text-[var(--amline-fg-muted)] transition-colors hover:bg-[var(--amline-surface-muted)] active:scale-95 lg:hidden"
             onClick={() => setMobileNavOpen(false)}
             aria-label="بستن منو"
           >
-            ×
+            <X className="h-5 w-5" strokeWidth={1.75} aria-hidden />
           </button>
         </div>
 
         <nav className="flex-1 overflow-y-auto py-3">
-          {navItems.map((item) => (
-            <NavLink
-              key={item.to}
-              to={item.to}
-              end={item.to === '/dashboard' || item.to === '/contracts'}
-              onClick={() => setMobileNavOpen(false)}
-              className={({ isActive }) =>
-                cn(
-                  'flex items-center gap-3 px-5 py-3 text-sm transition-colors',
-                  isActive
-                    ? 'border-r-4 border-[var(--amline-primary)] bg-[var(--amline-primary-muted)] font-semibold text-[var(--amline-primary)] dark:bg-blue-950/40'
-                    : 'text-[var(--amline-fg-muted)] hover:bg-[var(--amline-surface-muted)] hover:text-[var(--amline-fg)] dark:hover:bg-slate-800'
-                )
-              }
-            >
-              <span aria-hidden="true">{item.icon}</span>
-              <span>{item.label}</span>
-            </NavLink>
-          ))}
+          {navItems.map((item) => {
+            const Icon = item.icon;
+            return (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                end={item.to === '/dashboard' || item.to === '/contracts'}
+                onClick={() => setMobileNavOpen(false)}
+                className={({ isActive }) =>
+                  cn(
+                    'mx-2 flex items-center gap-3 rounded-xl px-4 py-3 text-sm transition-all duration-200 ease-out',
+                    isActive
+                      ? 'border-r-4 border-[var(--amline-primary)] bg-[var(--amline-primary-muted)] font-semibold text-[var(--amline-primary)] shadow-[var(--amline-shadow-sm)] dark:bg-blue-950/40'
+                      : 'border-r-4 border-transparent text-[var(--amline-fg-muted)] hover:bg-[var(--amline-surface-muted)] hover:text-[var(--amline-fg)] dark:hover:bg-slate-800'
+                  )
+                }
+              >
+                <Icon className="h-5 w-5 shrink-0 opacity-90" strokeWidth={1.75} aria-hidden />
+                <span>{item.label}</span>
+              </NavLink>
+            );
+          })}
         </nav>
 
         <div className="border-t border-[var(--amline-border)] p-4 dark:border-slate-700">

--- a/admin-ui/tests/real-auth-smoke.spec.ts
+++ b/admin-ui/tests/real-auth-smoke.spec.ts
@@ -18,7 +18,10 @@ test('smoke واقعی: ارسال OTP از فرم لاگین', async ({ page })
   await expect
     .poll(
       async () => {
-        const otpStep = await page.getByText(/کد ارسال شده به/).isVisible().catch(() => false);
+        const otpStep = await page
+          .getByText(/کد ارسال[\s\u200c]*شده به/)
+          .isVisible()
+          .catch(() => false);
         const mobileAgain = await page
           .getByRole('button', { name: /^ارسال کد تأیید$/ })
           .isVisible()

--- a/admin-ui/tsconfig.json
+++ b/admin-ui/tsconfig.json
@@ -23,7 +23,8 @@
     /* Path aliases */
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@amline/ui-core/*": ["../packages/amline-ui-core/src/*"]
     }
   },
   "include": ["src"],

--- a/admin-ui/vite.config.ts
+++ b/admin-ui/vite.config.ts
@@ -24,6 +24,9 @@ export default defineConfig(({ mode }) => {
         '@amline/ui-core': uiCoreRoot,
       },
     },
+    optimizeDeps: {
+      include: ['lucide-react'],
+    },
     server: {
       port: 3002,
       proxy: {

--- a/amline-ui/app/globals.css
+++ b/amline-ui/app/globals.css
@@ -47,12 +47,26 @@ html {
   -webkit-text-size-adjust: 100%;
 }
 
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
 body {
   font-family: var(--font-vazirmatn), 'Vazir', system-ui, sans-serif;
   font-size: 16px;
   line-height: 1.65;
   background-color: var(--amline-bg);
   color: var(--amline-fg);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+@layer base {
+  :where(a, button, input, textarea, select, summary, [tabindex]:not([tabindex='-1'])):focus-visible {
+    outline: 2px solid var(--amline-ring);
+    outline-offset: 2px;
+  }
 }
 
 .amline-display {

--- a/amline-ui/app/page.tsx
+++ b/amline-ui/app/page.tsx
@@ -1,49 +1,113 @@
 import Link from 'next/link'
+import { ArrowLeft, FileText, LogIn, PenLine, Sparkles, WalletCards } from 'lucide-react'
+
+type ActionItem = {
+  href: string
+  title: string
+  description: string
+  icon: typeof LogIn
+  emphasis: 'primary' | 'default'
+}
+
+const ACTIONS: ActionItem[] = [
+  {
+    href: '/login',
+    title: 'ورود با OTP',
+    description: 'ورود امن با شماره موبایل و کد یک‌بارمصرف',
+    icon: LogIn,
+    emphasis: 'default',
+  },
+  {
+    href: '/contracts',
+    title: 'قراردادها',
+    description: 'مشاهده وضعیت و جزئیات قراردادهای خود',
+    icon: FileText,
+    emphasis: 'primary',
+  },
+  {
+    href: '/contracts/wizard',
+    title: 'قرارداد جدید',
+    description: 'ویزارد گام‌به‌گام برای شروع انعقاد قرارداد',
+    icon: PenLine,
+    emphasis: 'default',
+  },
+  {
+    href: '/billing',
+    title: 'اشتراک و فاکتور',
+    description: 'مدیریت اشتراک و سوابق پرداخت',
+    icon: WalletCards,
+    emphasis: 'default',
+  },
+]
 
 export default function HomePage() {
   return (
-    <main className="mx-auto max-w-lg px-4 py-8 sm:px-6 sm:py-10">
-      <h1 className="amline-display text-[var(--amline-fg)]">پنل کاربری اَملاین</h1>
-      <p className="mt-3 text-sm leading-relaxed text-[var(--amline-fg-muted)] sm:text-base">
-        قراردادهای خود، نقش کاتب، طرف قرارداد یا شاهد را از اینجا مدیریت کنید.
-      </p>
-      <p className="mt-2 text-xs text-[var(--amline-fg-subtle)] sm:text-sm">
-        برای شروع انعقاد قرارداد، ابتدا از مسیر ورود با شماره موبایل وارد شوید.
-      </p>
-      <ul className="mt-8 space-y-3">
-        <li>
-          <Link
-            href="/login"
-            className="flex min-h-[52px] items-center rounded-amline border border-[var(--amline-border)] bg-[var(--amline-surface)] px-4 py-3 font-medium text-[var(--amline-fg)] shadow-[var(--amline-shadow-sm)] transition-colors hover:bg-[var(--amline-surface-muted)] dark:border-slate-700 dark:bg-[var(--amline-surface-elevated)] dark:hover:bg-slate-800"
-          >
-            ورود با OTP
-          </Link>
-        </li>
-        <li>
-          <Link
-            href="/contracts"
-            className="flex min-h-[52px] items-center rounded-amline border border-[var(--amline-primary)]/25 bg-[var(--amline-surface)] px-4 py-3 font-medium text-[var(--amline-primary)] shadow-amline transition-colors hover:bg-[var(--amline-primary-muted)] dark:bg-[var(--amline-surface-elevated)] dark:hover:bg-slate-800"
-          >
-            قراردادها
-          </Link>
-        </li>
-        <li>
-          <Link
-            href="/contracts/wizard"
-            className="flex min-h-[52px] items-center rounded-amline border border-[var(--amline-border)] bg-[var(--amline-surface)] px-4 py-3 font-medium text-[var(--amline-fg)] shadow-[var(--amline-shadow-sm)] transition-colors hover:bg-[var(--amline-surface-muted)] dark:border-slate-700 dark:bg-[var(--amline-surface-elevated)] dark:hover:bg-slate-800"
-          >
-            انعقاد قرارداد جدید
-          </Link>
-        </li>
-        <li>
-          <Link
-            href="/billing"
-            className="flex min-h-[52px] items-center rounded-amline border border-[var(--amline-border)] bg-[var(--amline-surface)] px-4 py-3 font-medium text-[var(--amline-fg)] shadow-[var(--amline-shadow-sm)] transition-colors hover:bg-[var(--amline-surface-muted)] dark:border-slate-700 dark:bg-[var(--amline-surface-elevated)] dark:hover:bg-slate-800"
-          >
-            اشتراک و فاکتور
-          </Link>
-        </li>
-      </ul>
+    <main className="relative min-h-[calc(100vh-4rem)] overflow-hidden px-4 py-10 sm:px-6 sm:py-14">
+      <div
+        className="pointer-events-none absolute inset-0 -z-10 opacity-90"
+        aria-hidden
+      >
+        <div className="absolute -left-32 top-0 h-72 w-72 rounded-full bg-[var(--amline-primary)]/10 blur-3xl dark:bg-blue-500/15" />
+        <div className="absolute -right-24 bottom-0 h-80 w-80 rounded-full bg-[var(--amline-accent)]/10 blur-3xl dark:bg-teal-500/10" />
+      </div>
+
+      <div className="mx-auto max-w-lg">
+        <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[var(--amline-border)] bg-[var(--amline-surface)] px-3 py-1 text-xs font-medium text-[var(--amline-fg-muted)] shadow-[var(--amline-shadow-sm)] dark:border-slate-700 dark:bg-slate-900/80">
+          <Sparkles className="h-3.5 w-3.5 text-[var(--amline-primary)]" strokeWidth={2} aria-hidden />
+          پنل کاربری اَملاین
+        </div>
+        <h1 className="amline-display text-balance text-[var(--amline-fg)]">
+          مدیریت قراردادهای ملکی
+        </h1>
+        <p className="mt-4 text-pretty text-sm leading-relaxed text-[var(--amline-fg-muted)] sm:text-base">
+          نقش کاتب، طرف قرارداد یا شاهد را از یک مکان منسجم پیگیری کنید؛ جریان ورود و شروع قرارداد
+          ساده و سریع طراحی شده است.
+        </p>
+
+        <ul className="mt-10 space-y-3 sm:space-y-4">
+          {ACTIONS.map(({ href, title, description, icon: Icon, emphasis }) => {
+            const isPrimary = emphasis === 'primary'
+            return (
+              <li key={href}>
+                <Link
+                  href={href}
+                  className={`group flex min-h-[4.5rem] items-start gap-4 rounded-2xl border px-4 py-4 shadow-[var(--amline-shadow-sm)] transition-all duration-200 ease-out hover:-translate-y-0.5 hover:shadow-[var(--amline-shadow-md)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--amline-ring)] active:translate-y-0 sm:min-h-[3.75rem] sm:items-center ${
+                    isPrimary
+                      ? 'border-[var(--amline-primary)]/35 bg-[var(--amline-surface)] text-[var(--amline-primary)] dark:border-blue-500/40 dark:bg-[var(--amline-surface-elevated)]'
+                      : 'border-[var(--amline-border)] bg-[var(--amline-surface)] text-[var(--amline-fg)] hover:border-[var(--amline-border-strong)] dark:border-slate-700 dark:bg-[var(--amline-surface-elevated)] dark:hover:border-slate-600'
+                  } `}
+                >
+                  <span
+                    className={`mt-0.5 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-colors duration-200 sm:mt-0 ${
+                      isPrimary
+                        ? 'bg-[var(--amline-primary-muted)] text-[var(--amline-primary)] group-hover:bg-[var(--amline-primary)]/20'
+                        : 'bg-[var(--amline-surface-muted)] text-[var(--amline-fg-muted)] group-hover:bg-[var(--amline-primary-muted)] group-hover:text-[var(--amline-primary)]'
+                    }`}
+                  >
+                    <Icon className="h-5 w-5" strokeWidth={1.75} aria-hidden />
+                  </span>
+                  <span className="min-w-0 flex-1 text-right">
+                    <span className="flex items-center justify-between gap-2">
+                      <span className="text-base font-semibold">{title}</span>
+                      <ArrowLeft
+                        className="h-4 w-4 shrink-0 opacity-0 transition-all duration-200 group-hover:translate-x-0.5 group-hover:opacity-100"
+                        aria-hidden
+                      />
+                    </span>
+                    <span className="mt-1 block text-xs leading-relaxed text-[var(--amline-fg-muted)] sm:text-sm">
+                      {description}
+                    </span>
+                  </span>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+
+        <p className="mt-10 text-center text-xs text-[var(--amline-fg-subtle)] sm:text-sm">
+          برای شروع، «ورود با OTP» را بزنید یا مستقیم سراغ قراردادها بروید.
+        </p>
+      </div>
     </main>
   )
 }

--- a/amline-ui/next.config.js
+++ b/amline-ui/next.config.js
@@ -1,9 +1,19 @@
+const path = require('path')
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
   experimental: {
     externalDir: true,
+  },
+  webpack: (config) => {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      '@': path.resolve(__dirname, '../admin-ui/src'),
+      '@amline/ui-core': path.resolve(__dirname, '../packages/amline-ui-core/src'),
+    }
+    return config
   },
   eslint: {
     ignoreDuringBuilds: true,

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -6,7 +6,27 @@
 :root {
   --brand: #1d4ed8;
   --brand-light: #3b82f6;
+  --brand-muted: rgba(29, 78, 216, 0.08);
 }
 
-html { scroll-behavior: smooth; }
-body { font-family: 'Vazirmatn', sans-serif; }
+@media (prefers-reduced-motion: no-preference) {
+  html {
+    scroll-behavior: smooth;
+  }
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: 'Vazirmatn', sans-serif;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+@layer base {
+  :where(a, button, input, textarea, select, summary, [tabindex]:not([tabindex='-1'])):focus-visible {
+    outline: 2px solid var(--brand);
+    outline-offset: 2px;
+  }
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,33 +1,48 @@
 import Link from 'next/link'
+import type { LucideIcon } from 'lucide-react'
+import {
+  Building2,
+  FileSignature,
+  FileText,
+  LayoutDashboard,
+  Shield,
+  Zap,
+} from 'lucide-react'
 
-const FEATURES = [
+type Feature = {
+  icon: LucideIcon
+  title: string
+  desc: string
+}
+
+const FEATURES: Feature[] = [
   {
-    icon: '📄',
+    icon: FileText,
     title: 'قرارداد دیجیتال',
     desc: 'انعقاد قرارداد رهن، اجاره و خرید و فروش به‌صورت کاملاً آنلاین و بدون نیاز به حضور فیزیکی.',
   },
   {
-    icon: '✍️',
+    icon: FileSignature,
     title: 'امضای الکترونیک',
     desc: 'امضای قانونی و معتبر برای همه طرفین قرارداد با تأیید هویت از طریق موبایل.',
   },
   {
-    icon: '🔐',
+    icon: Shield,
     title: 'امنیت بالا',
     desc: 'رمزنگاری end-to-end، ذخیره‌سازی امن اسناد و دسترسی کنترل‌شده برای هر نقش.',
   },
   {
-    icon: '📊',
+    icon: LayoutDashboard,
     title: 'مدیریت یکپارچه',
     desc: 'داشبورد مدیریتی برای پیگیری وضعیت قراردادها، کاربران و گزارش‌های مالی.',
   },
   {
-    icon: '⚡',
+    icon: Zap,
     title: 'سرعت و سادگی',
     desc: 'ویزارد گام‌به‌گام برای ثبت اطلاعات طرفین، ملک، تاریخ و شرایط مالی.',
   },
   {
-    icon: '🏢',
+    icon: Building2,
     title: 'مناسب بنگاه‌ها',
     desc: 'پنل اختصاصی برای مشاوران و بنگاه‌های معاملات ملکی با مدیریت چند کاربره.',
   },
@@ -40,59 +55,74 @@ const STEPS = [
   { num: '۴', title: 'امضا و تأیید', desc: 'همه طرفین امضا می‌کنند' },
 ]
 
+const navLinkClass =
+  'rounded-lg px-2 py-1 text-gray-600 transition-colors duration-200 hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700'
+
+const primaryBtnClass =
+  'rounded-xl bg-blue-700 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all duration-200 hover:bg-blue-800 hover:shadow-lg active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700'
+
+const secondaryBtnClass =
+  'rounded-xl border border-gray-300 bg-white px-4 py-2.5 text-sm font-semibold text-gray-700 transition-all duration-200 hover:border-gray-400 hover:bg-gray-50 active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700'
+
 export default function HomePage() {
   return (
     <>
-      {/* Navbar */}
-      <header className="sticky top-0 z-50 border-b border-gray-100 bg-white/95 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
-          <span className="text-2xl font-bold text-blue-700">اَملاین</span>
-          <nav className="hidden items-center gap-6 text-sm font-medium text-gray-600 sm:flex">
-            <a href="#features" className="hover:text-blue-700">ویژگی‌ها</a>
-            <a href="#how" className="hover:text-blue-700">نحوه کار</a>
-            <a href="#contact" className="hover:text-blue-700">تماس</a>
+      <header className="sticky top-0 z-50 border-b border-gray-200/80 bg-white/90 shadow-sm backdrop-blur-md supports-[backdrop-filter]:bg-white/75">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3.5 sm:px-6">
+          <span className="text-xl font-bold tracking-tight text-blue-800 sm:text-2xl">اَملاین</span>
+          <nav className="hidden items-center gap-5 text-sm font-medium sm:flex" aria-label="ناوبری اصلی">
+            <a href="#features" className={navLinkClass}>
+              ویژگی‌ها
+            </a>
+            <a href="#how" className={navLinkClass}>
+              نحوه کار
+            </a>
+            <a href="#contact" className={navLinkClass}>
+              تماس
+            </a>
           </nav>
-          <Link
-            href="https://app.amline.ir"
-            className="rounded-lg bg-blue-700 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-800"
-          >
+          <Link href="https://app.amline.ir" className={primaryBtnClass}>
             ورود به پنل
           </Link>
         </div>
       </header>
 
-      {/* Hero */}
-      <section className="bg-gradient-to-b from-blue-50 to-white px-4 py-20 text-center sm:px-6 sm:py-28">
+      <section className="relative overflow-hidden bg-gradient-to-b from-blue-50 via-white to-white px-4 py-16 text-center sm:px-6 sm:py-24">
+        <div
+          className="pointer-events-none absolute inset-0 -z-10"
+          aria-hidden
+        >
+          <div className="absolute left-1/2 top-0 h-64 w-[28rem] -translate-x-1/2 rounded-full bg-blue-200/40 blur-3xl" />
+        </div>
         <div className="mx-auto max-w-3xl">
-          <span className="inline-block rounded-full bg-blue-100 px-4 py-1.5 text-xs font-semibold text-blue-700">
+          <span className="inline-flex items-center rounded-full bg-blue-100/90 px-4 py-1.5 text-xs font-semibold text-blue-800 ring-1 ring-blue-200/60">
             پلتفرم هوشمند قرارداد ملکی
           </span>
-          <h1 className="mt-6 text-4xl font-extrabold leading-tight text-gray-900 sm:text-5xl">
+          <h1 className="mt-6 text-balance text-3xl font-extrabold leading-tight text-gray-900 sm:text-5xl">
             قرارداد ملکی خود را
             <br />
-            <span className="text-blue-700">آنلاین و امن</span> ببندید
+            <span className="bg-gradient-to-l from-blue-700 to-blue-600 bg-clip-text text-transparent">
+              آنلاین و امن
+            </span>{' '}
+            ببندید
           </h1>
-          <p className="mx-auto mt-6 max-w-xl text-lg leading-relaxed text-gray-600">
+          <p className="mx-auto mt-6 max-w-xl text-pretty text-base leading-relaxed text-gray-600 sm:text-lg">
             اَملاین بستری امن برای انعقاد، امضا و مدیریت قراردادهای رهن، اجاره و خرید و فروش ملک فراهم می‌کند.
           </p>
-          <div className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+          <div className="mt-10 flex flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-center">
             <Link
               href="https://app.amline.ir/contracts/wizard"
-              className="w-full rounded-xl bg-blue-700 px-8 py-3.5 text-base font-bold text-white shadow-lg hover:bg-blue-800 sm:w-auto"
+              className={`${primaryBtnClass} w-full px-8 py-3.5 text-base sm:w-auto`}
             >
               شروع رایگان
             </Link>
-            <a
-              href="#how"
-              className="w-full rounded-xl border border-gray-300 px-8 py-3.5 text-base font-semibold text-gray-700 hover:bg-gray-50 sm:w-auto"
-            >
+            <a href="#how" className={`${secondaryBtnClass} w-full px-8 py-3.5 text-base sm:w-auto`}>
               نحوه کار
             </a>
           </div>
         </div>
       </section>
 
-      {/* Stats */}
       <section className="border-y border-gray-100 bg-white py-10">
         <div className="mx-auto grid max-w-4xl grid-cols-2 gap-6 px-4 sm:grid-cols-4 sm:px-6">
           {[
@@ -102,49 +132,52 @@ export default function HomePage() {
             { val: '۲۴/۷', label: 'پشتیبانی آنلاین' },
           ].map((s) => (
             <div key={s.label} className="text-center">
-              <p className="text-3xl font-extrabold text-blue-700">{s.val}</p>
-              <p className="mt-1 text-sm text-gray-500">{s.label}</p>
+              <p className="text-2xl font-extrabold text-blue-700 sm:text-3xl">{s.val}</p>
+              <p className="mt-1 text-xs text-gray-500 sm:text-sm">{s.label}</p>
             </div>
           ))}
         </div>
       </section>
 
-      {/* Features */}
-      <section id="features" className="bg-gray-50 px-4 py-20 sm:px-6">
+      <section id="features" className="bg-gray-50 px-4 py-16 sm:px-6 sm:py-20">
         <div className="mx-auto max-w-6xl">
           <div className="mb-12 text-center">
-            <h2 className="text-3xl font-bold text-gray-900">چرا اَملاین؟</h2>
-            <p className="mt-3 text-gray-500">همه آنچه برای یک قرارداد حرفه‌ای نیاز دارید</p>
+            <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">چرا اَملاین؟</h2>
+            <p className="mt-3 text-sm text-gray-500 sm:text-base">همه آنچه برای یک قرارداد حرفه‌ای نیاز دارید</p>
           </div>
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {FEATURES.map((f) => (
-              <div
-                key={f.title}
-                className="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm transition hover:shadow-md"
-              >
-                <div className="mb-4 text-4xl">{f.icon}</div>
-                <h3 className="text-lg font-bold text-gray-900">{f.title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-gray-500">{f.desc}</p>
-              </div>
-            ))}
+          <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {FEATURES.map((f) => {
+              const Icon = f.icon
+              return (
+                <div
+                  key={f.title}
+                  className="group rounded-2xl border border-gray-200/90 bg-white p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:border-blue-200 hover:shadow-lg"
+                >
+                  <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-blue-50 text-blue-700 transition-colors duration-300 group-hover:bg-blue-100">
+                    <Icon className="h-6 w-6" strokeWidth={1.75} aria-hidden />
+                  </div>
+                  <h3 className="text-lg font-bold text-gray-900">{f.title}</h3>
+                  <p className="mt-2 text-sm leading-relaxed text-gray-500">{f.desc}</p>
+                </div>
+              )
+            })}
           </div>
         </div>
       </section>
 
-      {/* How it works */}
-      <section id="how" className="bg-white px-4 py-20 sm:px-6">
+      <section id="how" className="bg-white px-4 py-16 sm:px-6 sm:py-20">
         <div className="mx-auto max-w-4xl">
           <div className="mb-12 text-center">
-            <h2 className="text-3xl font-bold text-gray-900">نحوه کار</h2>
-            <p className="mt-3 text-gray-500">در چهار گام ساده قرارداد خود را ببندید</p>
+            <h2 className="text-2xl font-bold text-gray-900 sm:text-3xl">نحوه کار</h2>
+            <p className="mt-3 text-sm text-gray-500 sm:text-base">در چهار گام ساده قرارداد خود را ببندید</p>
           </div>
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
             {STEPS.map((s, i) => (
               <div key={s.num} className="relative text-center">
                 {i < STEPS.length - 1 && (
-                  <div className="absolute left-0 top-6 hidden h-0.5 w-full bg-blue-100 lg:block" />
+                  <div className="absolute left-0 top-6 hidden h-0.5 w-full bg-gradient-to-l from-blue-100 to-transparent lg:block" />
                 )}
-                <div className="relative mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-700 text-xl font-bold text-white">
+                <div className="relative mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-blue-700 to-blue-600 text-lg font-bold text-white shadow-md ring-4 ring-blue-50">
                   {s.num}
                 </div>
                 <h3 className="mt-4 font-bold text-gray-900">{s.title}</h3>
@@ -155,29 +188,30 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* CTA */}
-      <section className="bg-blue-700 px-4 py-16 text-center sm:px-6">
+      <section className="bg-gradient-to-br from-blue-700 to-blue-900 px-4 py-14 text-center sm:px-6 sm:py-16">
         <div className="mx-auto max-w-2xl">
-          <h2 className="text-3xl font-bold text-white">همین حالا شروع کنید</h2>
-          <p className="mt-4 text-blue-100">
+          <h2 className="text-2xl font-bold text-white sm:text-3xl">همین حالا شروع کنید</h2>
+          <p className="mt-4 text-sm leading-relaxed text-blue-100 sm:text-base">
             ثبت‌نام رایگان است. اولین قرارداد خود را در کمتر از ۱۰ دقیقه ببندید.
           </p>
           <Link
             href="https://app.amline.ir"
-            className="mt-8 inline-block rounded-xl bg-white px-8 py-3.5 text-base font-bold text-blue-700 shadow hover:bg-blue-50"
+            className="mt-8 inline-block rounded-xl bg-white px-8 py-3.5 text-base font-bold text-blue-700 shadow-lg transition-all duration-200 hover:bg-blue-50 hover:shadow-xl active:scale-[0.98] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           >
             ورود به اَملاین
           </Link>
         </div>
       </section>
 
-      {/* Footer */}
       <footer id="contact" className="border-t border-gray-100 bg-white px-4 py-10 sm:px-6">
-        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 sm:flex-row">
-          <span className="text-xl font-bold text-blue-700">اَملاین</span>
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 text-center sm:flex-row sm:text-right">
+          <span className="text-xl font-bold text-blue-800">اَملاین</span>
           <p className="text-sm text-gray-500">
             تماس:{' '}
-            <a href="mailto:info@amline.ir" className="text-blue-600 hover:underline">
+            <a
+              href="mailto:info@amline.ir"
+              className="font-medium text-blue-600 underline-offset-2 transition-colors hover:text-blue-800 hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-700"
+            >
               info@amline.ir
             </a>
           </p>


### PR DESCRIPTION
## زمینه
- **PR شماره ۱** (بهبود sweep: مستندات و پایداری e2e) همچنان **باز** است؛ این PR جداگانه است و روی **ظاهر و تجربهٔ کاربر** تمرکز دارد.

## برنامه و معیار پذیرش (خلاصه)
| ناحیه | بهبود | معیار |
|--------|--------|--------|
| admin-ui | آیکون‌های حرفه‌ای (Lucide)، منوی واکنش‌گرا، فوکوس مرئی، پیش‌بارگذاری lucide در Vite | سایدبار و هدر موبایل خوانا، بدون شکست e2e |
| amline-ui | صفحهٔ اصلی کارت‌محور، گرادیان ظریف، حرکت hover، فوکوس و اسکرول نرم | `next build` سبز |
| site | لندینگ با آیکون Lucide، کارت‌های تعاملی، دکمه‌ها و لینک‌ها با فوکوس مرئی | خروجی استاتیک سبز |

## تغییرات فنی
### admin-ui
- جایگزینی ایموجی نوار کناری و هدر با **Lucide**؛ بهبود سایه، `backdrop-blur` و انیمیشن سایدبار.
- لایهٔ **`:focus-visible`** در `index.css` برای دسترسی‌پذیری؛ `prefers-reduced-motion` فقط برای `scroll-behavior`.
- **`optimizeDeps.include: ['lucide-react']`** برای جلوگیری از timeout اولیهٔ Playwright هنگام پیش‌بهینه‌سازی.
- **`tsconfig`**: alias `@amline/ui-core/*` برای `tsc` (هم‌راستا با PR قبلی).
- **Playwright**: `workers: 2`، `VITE_ENABLE_DEV_BYPASS: 'true'`، اصلاح تست smoke برای نیم‌فاصله در متن OTP.
- وابستگی‌های **`posthog-js`** و **`maplibre-gl`** در `package.json` (در صورت نبود، build می‌شکست).

### amline-ui
- بازطراحی **`app/page.tsx`**: کارت‌های اقدام با آیکون، متن توضیحی و حالت hover.
- **`globals.css`**: فوکوس مرئی، انتقال نرم پس‌زمینهٔ بدنه، اسکرول نرم (با رعایت کاهش حرکت).
- **`next.config.js`**: aliasهای webpack برای `@` و `@amline/ui-core` نسبت به `admin-ui` و `packages` تا **بیلد monorepo** پایدار شود.

### site
- **`page.tsx`**: آیکون‌های Lucide برای ویژگی‌ها، بهبود هیرو (گرادیان متن)، کارت‌ها و CTA با transition و فوکوس.
- **`globals.css`**: متغیر `--brand-muted`، فوکوس مرئی، اسکرول نرم.

## نتایج تست (محلی)
- `pytest` در `backend/backend`: **۵۵ passed** (بدون تغییر کد بک‌اند؛ فقط اجرای رگرسیون).
- `admin-ui`: **`npm run build`**، **`npm test` (Vitest)**، **`npx playwright test`**: **۲۱ passed**.
- `amline-ui`: **`npm run build`**: موفق.
- `site`: **`npm run build`**: موفق.

## پیش‌نمایش محلی
با `npm run dev` در هر پوشه (پورت‌ها را طبق قرارداد پروژه تنظیم کنید):
- پنل ادمین: `http://localhost:3002`
- پنل کاربر: `http://localhost:3000`
- لندینگ: `http://localhost:3001`

## محدودیت ابزار
باز کردن **مرورگر داخلی Cursor** از این محیط عامل پشتیبانی نمی‌شود؛ لطفاً همان آدرس‌های بالا را در مرورگر سیستم یا Simple Browser خودتان باز کنید.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI/UX and build/test config changes, but it also introduces new runtime dependencies (`posthog-js`, `maplibre-gl`) and bundler/alias tweaks that can affect build output and client-side behavior.
> 
> **Overview**
> Improves UI polish and accessibility across **admin-ui**, **amline-ui**, and the marketing **site** by adding consistent `:focus-visible` styles, reduced-motion handling, and refreshed layouts/components (notably replacing emoji icons with `lucide-react` icons and updating hover/transition styling).
> 
> Stabilizes builds and e2e runs by adding missing runtime deps (`posthog-js`, `maplibre-gl`), pre-optimizing `lucide-react` in Vite, expanding TS/webpack aliases for monorepo imports, and adjusting Playwright config/tests (fixed OTP text matching, forced dev bypass, set `workers: 2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9cd7028a5700f889e318c4368736f21dd07f725. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->